### PR TITLE
Compile programs

### DIFF
--- a/Server/Source/Servers/fcgi.prg
+++ b/Server/Source/Servers/fcgi.prg
@@ -3,8 +3,8 @@
 *--- Change window caption
 _VFP.Caption = FOX_PAGES_VERSION+" - FCGI"
 
-*--- Set path
-set path to "core"
+*--- Compile programs
+compile ..\core\*.prg
 
 *--- Create server
 PUBLIC FPServer

--- a/Server/Source/Servers/http.prg
+++ b/Server/Source/Servers/http.prg
@@ -3,8 +3,8 @@
 *--- Change window caption
 _VFP.Caption = FOX_PAGES_VERSION+" - HTTP"
 
-*--- Set path
-set path to "core"
+*--- Compile programs
+compile ..\core\*.prg
 
 *--- Create server
 PUBLIC FPServer

--- a/Server/Source/Servers/https.prg
+++ b/Server/Source/Servers/https.prg
@@ -3,8 +3,8 @@
 *--- Change window caption
 _VFP.Caption = FOX_PAGES_VERSION+" - HTTPS"
 
-*--- Set path
-set path to "core"
+*--- Compile programs
+compile ..\core\*.prg
 
 *--- Create server
 PUBLIC FPServer


### PR DESCRIPTION
The servers start programs must compile all CORE programs to avoid debugger issues and missing files.